### PR TITLE
Added search initialisation

### DIFF
--- a/salt/search/init.sls
+++ b/salt/search/init.sls
@@ -52,7 +52,7 @@ composer-install:
 
 search-ensure-index:
     cmd.run:
-        - name: php bin/console search:setup
+        - name: ./bin/console search:setup
         - cwd: /srv/search/
         - user: {{ pillar.elife.deploy_user.username }}
         - require:

--- a/salt/search/init.sls
+++ b/salt/search/init.sls
@@ -41,7 +41,7 @@ composer-install:
         {% if pillar.elife.env in ['prod', 'demo', 'end2end'] %}
         - name: composer1.0 --no-interaction install --classmap-authoritative --no-dev
         {% elif pillar.elife.env in ['ci'] %}
-        - name: composer1.0 --no-interaction install --classmap-authoritative 
+        - name: composer1.0 --no-interaction install --classmap-authoritative
         {% else %}
         - name: composer1.0 --no-interaction install
         {% endif %}
@@ -49,6 +49,14 @@ composer-install:
         - user: {{ pillar.elife.deploy_user.username }}
         - require:
             - search-cache
+
+search-ensure-index:
+    cmd.run:
+        - name: php bin/console search:setup
+        - cwd: /srv/search/
+        - user: {{ pillar.elife.deploy_user.username }}
+        - require:
+            - composer-install
 
 search-nginx-vhost:
     file.managed:


### PR DESCRIPTION
@giorgiosironi

I'm not sure if I have to do anything further to get this to run. This command will be production-safe, and will only update mappings on deployment and ensure there is always an index on the configured Elasticsearch server. Even if there is no data yet, it will allow CI to show an empty set without results to a static data set.

Also, how do you propose we go about populating some test data for CI, or other environments?