### PR TITLE
Added importing of content

### DIFF
--- a/salt/search/init.sls
+++ b/salt/search/init.sls
@@ -57,6 +57,17 @@ search-ensure-index:
         - require:
             - composer-install
 
+{% if pillar.elife.env in ['dev', 'ci'] %}
+search-import-content:
+    cmd.run:
+        - name: ./bin/console gearman:import all
+        - cwd: /srv/search/
+        - user: {{ pillar.elife.deploy_user.username }}
+        - require:
+            - search-ensure-index
+            - search-gearman-worker-service
+{% endif %}
+
 search-nginx-vhost:
     file.managed:
         - name: /etc/nginx/sites-enabled/search.conf


### PR DESCRIPTION
@giorgiosironi @lsh-0 

This will kick off the importing of content from the Dummy api. I've set this to only run on dev and CI. Is this the correct route to go?

This is still a WIP as the dummy-api needs to be spun up first