### PR TITLE
ElasticSearch binding hostname

### DIFF
--- a/salt/search/config/etc-elasticsearch-elasticsearch.yml
+++ b/salt/search/config/etc-elasticsearch-elasticsearch.yml
@@ -4,3 +4,4 @@
 node.name: "{{ salt['elife.cfg']('project.stackname') }}"
 http.cors.allow-origin: "/.*/"
 http.cors.enabled: true
+network.host: {{ salt['elife.cfg']('cfn.outputs.PrivateIP') }}


### PR DESCRIPTION
Turns out this is localhost by default, and won't accept connections from other nodes