### PR TITLE
Restart processes less aggressively

### DIFF
--- a/salt/search/config/etc-init-search-gearman-worker.conf
+++ b/salt/search/config/etc-init-search-gearman-worker.conf
@@ -1,7 +1,7 @@
 description "search-gearman-worker - pass an ID to distinguish between them e.g. sudo start search-gearman-worker ID=1"
 respawn
-respawn limit 10 30
-kill timeout 70 # configure at will
+respawn limit 30 30
+kill timeout 40 # 20 second polling timeout, 20 seconds of possible execution
 setuid {{ pillar.elife.deploy_user.username }}
 env HOME=/home/{{ pillar.elife.deploy_user.username }}
 instance $ID
@@ -9,3 +9,4 @@ chdir /srv/search
 script
     exec php bin/console gearman:worker -e {{ pillar.elife.env }} $ID
 end script
+post-stop exec sleep 1

--- a/salt/search/config/etc-init-search-queue-watch.conf
+++ b/salt/search/config/etc-init-search-queue-watch.conf
@@ -1,7 +1,7 @@
 description "search-queue-watch Will listen to the SQS queue and pass items to gearman to import"
 respawn
-respawn limit 10 30
-kill timeout 70
+respawn limit 30 30
+kill timeout 40 # 20 seconds polling timeout, 20 seconds of possible execution
 setuid {{ pillar.elife.deploy_user.username }}
 env HOME=/home/{{ pillar.elife.deploy_user.username }}
 instance $ID
@@ -9,3 +9,4 @@ chdir /srv/search
 script
     exec php bin/console queue:watch -e {{ pillar.elife.env }} $ID
 end script
+post-stop exec sleep 1


### PR DESCRIPTION
Insert a 1 second pause after each stop. Never stop respawning essentially, but thanks to the sleep we shouldn't create too much load if a process continues crashing.

Comes from a problem on boot in which Elasticsearch is not ready to
serve requests, but the processes try to connect to it to get the
index-metadata from the index used as a key-value store.