### PR TITLE
Feature: switches a manual invocation of 'search-processes' to an upstart one

### DIFF
--- a/salt/search/processes.sls
+++ b/salt/search/processes.sls
@@ -20,10 +20,12 @@ search-processes-task:
             {% endfor %}
 
 search-processes-start:
-    cmd.run:
-        - name: start search-processes
+    service.running:
+        - name: search-processes
         - require:
             - search-processes-task
+        - watch:
+            - aws-credentials-deploy-user
 
 search-gearman-worker-stop-all-task:
     file.managed:


### PR DESCRIPTION
the upstart service watches the aws credentials and is restarted when it changes.

update: might be able to leave that change to 'cmd.run' as-is if watch requisites work with them as well