### PR TITLE
Feature: adds repo.path setting to elasticsearch

### DIFF
--- a/salt/search/config/etc-elasticsearch-elasticsearch.yml
+++ b/salt/search/config/etc-elasticsearch-elasticsearch.yml
@@ -9,3 +9,5 @@ network.host: 127.0.0.1,{{ salt['elife.cfg']('cfn.outputs.PrivateIP1') }}
 {% else %}
 network.host: 127.0.0.1
 {% endif %}
+
+repo.path: ["/var/lib/elasticsearch/repo"]

--- a/salt/search/gearman-persistence.sls
+++ b/salt/search/gearman-persistence.sls
@@ -35,8 +35,8 @@ gearman-configuration:
     cmd.run:
         # I do not trust anymore Upstart to see changes to init scripts when using `restart` alone
         - name: |
-            stop gearman-job-server
-            start gearman-job-server
+            systemctl stop gearman-job-server || stop gearman-job-server
+            systemctl start gearman-job-server || start gearman-job-server
         - onchanges:
             - file: gearman-configuration
 {% endif %}


### PR DESCRIPTION
To create snapshots, elasticsearch needs a [repository](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/modules-snapshots.html#modules-snapshots) to put them in. This repository is shared and synced with all other nodes in the ES cluster (in our case, a single node, the leader).

If this setting doesn't exist, snapshots can't be made it and you get this:

> $ curl -XPUT localhost:9200/_snapshot/2019-08-backup -d '{"type": "fs", "settings": {"location": "/tmp/backup"}}' | jq .

```json
{
  "error": {
    "root_cause": [
      {
        "type": "repository_exception",
        "reason": "[2019-08-backup] failed to create repository"
      }
    ],
    "type": "repository_exception",
    "reason": "[2019-08-backup] failed to create repository",
    "caused_by": {
      "type": "creation_exception",
      "reason": "Guice creation errors:\n\n1) Error injecting constructor, RepositoryException[[2019-08-backup] location [/tmp/backup] doesn't match any of the locations specified by path.repo because this setting is empty]\n  at org.elasticsearch.repositories.fs.FsRepository.<init>(Unknown Source)\n  while locating org.elasticsearch.repositories.fs.FsRepository\n  while locating org.elasticsearch.repositories.Repository\n\n1 error",
      "caused_by": {
        "type": "repository_exception",
        "reason": "[2019-08-backup] location [/tmp/backup] doesn't match any of the locations specified by path.repo because this setting is empty"
      }
    }
  },
  "status": 500
}
```

the elasticsearch service will restart after the config changes and we should then be able to create snapshots.

snapshots can then be created, the results can be tarred+gzipped and distributed about and restored (yet to be tested).