### PR TITLE
Fix: gearman service now waits until postgres service is running

### DIFF
--- a/salt/search/config/lib-systemd-system-gearman-job-server.service
+++ b/salt/search/config/lib-systemd-system-gearman-job-server.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=gearman job control server
+After=postgresql.service
 
 [Service]
 ExecStartPre=/usr/bin/install -d -o gearman /run/gearman


### PR DESCRIPTION
stopping and starting an instance would leave gearman-job-service in a failed state as it tried to start before postgresql which it needs to be available.

cc @giorgiosironi 