### PR TITLE
Allow processes to restart on boot

### DIFF
--- a/salt/search/config/lib-systemd-system-search-gearman-worker@.service
+++ b/salt/search/config/lib-systemd-system-search-gearman-worker@.service
@@ -8,7 +8,9 @@ WantedBy={{ process }}-controller.target
 
 [Service]
 Restart=on-failure
-#RestartSec=10
+StartLimitIntervalSec=30
+StartLimitBurst=30
+RestartSec=1
 TimeoutStopSec=70
 User={{ pillar.elife.deploy_user.username }}
 Environment="HOME=/home/{{ pillar.elife.deploy_user.username }}"

--- a/salt/search/config/lib-systemd-system-search-queue-watch@.service
+++ b/salt/search/config/lib-systemd-system-search-queue-watch@.service
@@ -8,7 +8,9 @@ WantedBy={{ process }}-controller.target
 
 [Service]
 Restart=on-failure
-#RestartSec=10
+StartLimitIntervalSec=30
+StartLimitBurst=30
+RestartSec=1
 TimeoutStopSec=70
 User={{ pillar.elife.deploy_user.username }}
 Environment="HOME=/home/{{ pillar.elife.deploy_user.username }}"


### PR DESCRIPTION
See https://github.com/elifesciences/issues/issues/5087

Empirically, `end2end` takes less than 10 seconds to make the
ElasticSearch daemon available for PHP processes to use:
```
elife@end2end--search:~$ sudo journalctl -u search-queue-watch@0 | grep
Fatal | grep -o "Sep 16 11:52:.."
Sep 16 11:52:39
Sep 16 11:52:41
Sep 16 11:52:42
Sep 16 11:52:43
Sep 16 11:52:45
Sep 16 11:52:46
Sep 16 11:52:47
```

This is roughly a porting of the [Upstart version](https://github.com/elifesciences/search-formula/pull/39/files#diff-fdd396bd8e102f0db64330b067a30c57L3) which allows 30 restarts in 30 seconds. There is a 1 second break between restarts as a form of simple backoff.