### PR TITLE
Provisioning a config.php file

### DIFF
--- a/salt/pillar/search.sls
+++ b/salt/pillar/search.sls
@@ -4,9 +4,6 @@ search:
         requests_batch: 10
 
     aws:
-        access_key_id: null
-        secret_access_key: null
-        region: us-east-1
         endpoint: http://localhost:4100
 
     elasticsearch:

--- a/salt/pillar/search.sls
+++ b/salt/pillar/search.sls
@@ -1,15 +1,31 @@
 search:
+    api:
+        url: http://localhost:8080
+        requests_batch: 10
+
     aws:
         access_key_id: null
         secret_access_key: null
         region: us-east-1
+        endpoint: http://localhost:4100
 
-    # deprecated and is now found in elife.gearman.db
+    elasticsearch:
+        servers: http://localhost:9200 
+        logging: true
+        force_sync: true
+
     gearman:
+        servers: 127.0.0.1
+        # deprecated and is now found in elife.gearman.db
         db:
             name: gearman
             username: gearman
             password: gearman
+
+    debug: true
+    validate: true
+    ttl: 0
+    rate_limit_minimum_page: 2
 
 elife:
     gearman:

--- a/salt/search/config/srv-search-config.php
+++ b/salt/search/config/srv-search-config.php
@@ -14,7 +14,7 @@ return [
     'api_requests_batch' => {{ pillar.search.api.requests_batch }},
     'rate_limit_minimum_page' => {{ pillar.search.rate_limit_minimum_page }},
     'aws' => [
-        'queue_name' => 'search--{{ pillar.elife.env }}',
+        'queue_name' => 'search--{{ salt['elife.cfg']('project.instance_id') }}',
         'credential_file' => true,
         'region' => 'us-east-1',
         {% if pillar.search.aws.endpoint %}

--- a/salt/search/config/srv-search-config.php
+++ b/salt/search/config/srv-search-config.php
@@ -14,7 +14,7 @@ return [
     'api_requests_batch' => {{ pillar.search.api.requests_batch }},
     'rate_limit_minimum_page' => {{ pillar.search.rate_limit_minimum_page }},
     'aws' => [
-        'queue_name' => 'search--prod',
+        'queue_name' => 'search--{{ pillar.elife.env }}',
         'credential_file' => true,
         'region' => 'us-east-1',
         {% if pillar.search.aws.endpoint %}

--- a/salt/search/config/srv-search-config.php
+++ b/salt/search/config/srv-search-config.php
@@ -1,0 +1,25 @@
+<?php
+
+use Monolog\Logger;
+
+return [
+    'debug' => {% if pillar.search.debug %}true{% else %}false{% endif %},
+    'validate' => {% if pillar.search.validate %}true{% else %}false{% endif %},
+    'ttl' => {{ pillar.search.ttl }},
+    'elastic_servers' => ['{{ pillar.search.elasticsearch.servers }}'],
+    'elastic_logging' => {% if pillar.search.elasticsearch.logging %}true{% else %}false{% endif %},
+    'elastic_force_sync' => {% if pillar.search.elasticsearch.force_sync %}true{% else %}false{% endif %},
+    'gearman_servers' => ['{{ pillar.search.gearman.servers }}'],
+    'api_url' => '{{ pillar.search.api.url }}',
+    'api_requests_batch' => {{ pillar.search.api.requests_batch }},
+    'rate_limit_minimum_page' => {{ pillar.search.rate_limit_minimum_page }},
+    'aws' => [
+        'queue_name' => 'search--prod',
+        'credential_file' => true,
+        'region' => 'us-east-1',
+        {% if pillar.search.aws.endpoint %}
+        'endpoint' => '{{ pillar.search.aws.endpoint }}',
+        {% endif %}
+    ],
+    //'logger.level' => Logger::INFO,
+];

--- a/salt/search/config/srv-search-config.php
+++ b/salt/search/config/srv-search-config.php
@@ -21,5 +21,4 @@ return [
         'endpoint' => '{{ pillar.search.aws.endpoint }}',
         {% endif %}
     ],
-    //'logger.level' => Logger::INFO,
 ];

--- a/salt/search/init.sls
+++ b/salt/search/init.sls
@@ -68,6 +68,14 @@ search-cache-clean:
         - require:
             - search-cache
 
+search-configuration-file:
+    file.managed:
+        - name: /srv/search/config.php
+        - source: salt://search/config/srv-search-config.php
+        - template: jinja
+        - require:
+            - search-repository
+
 # useful for smoke testing the JSON output
 search-jq:
     pkg.installed:

--- a/salt/search/leader.sls
+++ b/salt/search/leader.sls
@@ -20,6 +20,7 @@ search-console-ready:
             - gearman-service
             - elasticsearch-ready
             - search-composer-install
+            - search-configuration-file
             - aws-credentials-deploy-user
 
 search-ensure-index:


### PR DESCRIPTION
Depends on [`builder-configuration` having all the pillars](https://github.com/elifesciences/builder-configuration/pull/115), but works locally.