### PR TITLE
Always restart PHP long-running processes

### DIFF
--- a/salt/search/config/lib-systemd-system-search-gearman-worker@.service
+++ b/salt/search/config/lib-systemd-system-search-gearman-worker@.service
@@ -7,7 +7,7 @@ PartOf={{ process }}-controller.target
 WantedBy={{ process }}-controller.target
 
 [Service]
-Restart=on-failure
+Restart=always
 StartLimitIntervalSec=30
 StartLimitBurst=30
 RestartSec=1

--- a/salt/search/config/lib-systemd-system-search-queue-watch@.service
+++ b/salt/search/config/lib-systemd-system-search-queue-watch@.service
@@ -7,7 +7,7 @@ PartOf={{ process }}-controller.target
 WantedBy={{ process }}-controller.target
 
 [Service]
-Restart=on-failure
+Restart=always
 StartLimitIntervalSec=30
 StartLimitBurst=30
 RestartSec=1


### PR DESCRIPTION
These processes can exit with 0 due to a memory limit being reached due to leaks:
https://github.com/elifesciences/search/blob/10082f0f71bc8f9d69c13ffa02fb10426404b71c/src/Search/Kernel.php#L212

Reference for `Restart`:
https://www.freedesktop.org/software/systemd/man/systemd.service.html