### PR TITLE
logging, raises 'action' property from 'debug' to 'info'.

### DIFF
--- a/salt/search/config/etc-elasticsearch-logging.yml
+++ b/salt/search/config/etc-elasticsearch-logging.yml
@@ -3,7 +3,9 @@ es.logger.level: INFO
 rootLogger: ${es.logger.level}, console, file
 logger:
   # log action execution errors for easier debugging
-  action: DEBUG
+  # lsh@2020-12: raised level for production in hopes of preventing stacktrace spam when under load. Not sure it works.
+  #action: DEBUG
+  action: {% if pillar.elife.env in ['prod'] %}INFO{% else %}DEBUG{% endif %}
 
   # deprecation logging, turn to DEBUG to see them
   deprecation: INFO, deprecation_log_file


### PR DESCRIPTION
this is in hopes of suppressing the stacktraces that are filling the log and the disk when the request queue fills up under load.
it appears to work in adhoc testing with no stacktrace present when doing a smoke test during startup.